### PR TITLE
Split Error::Config into Tool and Glob variants

### DIFF
--- a/crates/cargo-context-core/src/collect/diff.rs
+++ b/crates/cargo-context-core/src/collect/diff.rs
@@ -142,7 +142,7 @@ fn run_git(root: &Path, args: &[String]) -> Result<String> {
         .current_dir(root)
         .args(args)
         .output()
-        .map_err(|e| Error::Config(format!("failed to spawn git: {e}")))?;
+        .map_err(|e| Error::Tool(format!("failed to spawn git: {e}")))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         // A non-repo, missing HEAD, or "use --no-index" nudge is legitimately
@@ -154,7 +154,7 @@ fn run_git(root: &Path, args: &[String]) -> Result<String> {
         {
             return Ok(String::new());
         }
-        return Err(Error::Config(format!(
+        return Err(Error::Tool(format!(
             "git {:?} failed: {}",
             args,
             stderr.trim()

--- a/crates/cargo-context-core/src/collect/errors.rs
+++ b/crates/cargo-context-core/src/collect/errors.rs
@@ -113,7 +113,7 @@ pub fn last_error(root: &Path) -> Result<Diagnostics> {
             "--color=never",
         ])
         .output()
-        .map_err(|e| Error::Config(format!("failed to spawn cargo: {e}")))?;
+        .map_err(|e| Error::Tool(format!("failed to spawn cargo: {e}")))?;
 
     let stream = String::from_utf8_lossy(&output.stdout);
     let diagnostics = parse_message_stream(&stream);

--- a/crates/cargo-context-core/src/collect/meta.rs
+++ b/crates/cargo-context-core/src/collect/meta.rs
@@ -75,7 +75,7 @@ pub fn cargo_metadata(root: &Path) -> Result<WorkspaceMap> {
         .current_dir(root)
         .no_deps()
         .exec()
-        .map_err(|e| Error::Config(format!("cargo metadata failed: {e}")))?;
+        .map_err(|e| Error::Tool(format!("cargo metadata failed: {e}")))?;
 
     let root_package = meta.root_package().map(|p| p.name.clone());
     let members: Vec<WorkspaceMember> = meta

--- a/crates/cargo-context-core/src/error.rs
+++ b/crates/cargo-context-core/src/error.rs
@@ -17,6 +17,12 @@ pub enum Error {
     #[error("budget exceeded: {actual} tokens > {limit}")]
     BudgetExceeded { actual: usize, limit: usize },
 
+    #[error("external tool failed: {0}")]
+    Tool(String),
+
+    #[error("invalid glob: {0}")]
+    Glob(String),
+
     #[error("invalid configuration: {0}")]
     Config(String),
 

--- a/crates/cargo-context-core/src/expand.rs
+++ b/crates/cargo-context-core/src/expand.rs
@@ -65,7 +65,7 @@ pub fn expand_file(workspace_root: &Path, crate_name: &str, file: &Path) -> Resu
         .arg("--color=never")
         .current_dir(workspace_root)
         .output()
-        .map_err(|e| Error::Config(format!("failed to spawn cargo-expand: {e}")))?;
+        .map_err(|e| Error::Tool(format!("failed to spawn cargo-expand: {e}")))?;
 
     if !output.status.success() {
         // Expansion failed (e.g. the crate doesn't compile). Fall through

--- a/crates/cargo-context-core/src/scrub/paths.rs
+++ b/crates/cargo-context-core/src/scrub/paths.rs
@@ -66,8 +66,7 @@ fn build_globset(patterns: &[String]) -> Result<GlobSet> {
         let glob = Glob::new(p).map_err(|e| Error::Glob(format!("invalid glob `{p}`: {e}")))?;
         b.add(glob);
     }
-    b.build()
-        .map_err(|e| Error::Glob(format!("globset: {e}")))
+    b.build().map_err(|e| Error::Glob(format!("globset: {e}")))
 }
 
 #[cfg(test)]

--- a/crates/cargo-context-core/src/scrub/paths.rs
+++ b/crates/cargo-context-core/src/scrub/paths.rs
@@ -63,11 +63,11 @@ impl PathRules {
 fn build_globset(patterns: &[String]) -> Result<GlobSet> {
     let mut b = GlobSetBuilder::new();
     for p in patterns {
-        let glob = Glob::new(p).map_err(|e| Error::Config(format!("invalid glob `{p}`: {e}")))?;
+        let glob = Glob::new(p).map_err(|e| Error::Glob(format!("invalid glob `{p}`: {e}")))?;
         b.add(glob);
     }
     b.build()
-        .map_err(|e| Error::Config(format!("globset: {e}")))
+        .map_err(|e| Error::Glob(format!("globset: {e}")))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds `Error::Tool(String)` for external tool failures (git, cargo, cargo-expand)
- Adds `Error::Glob(String)` for invalid glob patterns  
- Keeps `Error::Config(String)` for genuine config issues

Moved 7 call sites to the appropriate variant:
- `diff.rs` – git spawn and non-zero exit → `Tool`
- `errors.rs` – cargo spawn → `Tool`
- `meta.rs` – cargo metadata → `Tool`
- `expand.rs` – cargo-expand spawn → `Tool`
- `paths.rs` – invalid glob and globset build → `Glob`

Closes #6