### PR TITLE
Extract pack.rs into pack/{mod,render,impact}.rs submodules

### DIFF
--- a/crates/cargo-context-core/src/pack/impact.rs
+++ b/crates/cargo-context-core/src/pack/impact.rs
@@ -1,0 +1,185 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::impact::Finding;
+use crate::scrub::Scrubber;
+
+use super::render::lang_for_path;
+
+fn format_file_header(path: &Path, findings: &[&Finding]) -> String {
+    let mut header = format!("### `{}`", path.display());
+    let labels: Vec<String> = findings
+        .iter()
+        .map(|f| {
+            let id = f.id.as_deref().unwrap_or("finding");
+            let d = f.descriptor();
+            if d.is_empty() {
+                id.to_string()
+            } else {
+                format!("{id}: {d}")
+            }
+        })
+        .collect();
+    if !labels.is_empty() {
+        header.push_str(" — ");
+        header.push_str(&labels.join("; "));
+    }
+    header
+}
+
+pub(super) fn try_collect_scoped(
+    root: &Path,
+    paths: &[PathBuf],
+    scrubber: &Scrubber,
+) -> Option<String> {
+    let mut body = String::new();
+    let mut included = 0_usize;
+    let mut skipped = 0_usize;
+
+    for rel in paths {
+        let abs = if rel.is_absolute() {
+            rel.clone()
+        } else {
+            root.join(rel)
+        };
+        if !abs.is_file() {
+            skipped += 1;
+            continue;
+        }
+        let raw = match std::fs::read_to_string(&abs) {
+            Ok(s) => s,
+            Err(_) => {
+                skipped += 1;
+                continue;
+            }
+        };
+        let (content, _report) = scrubber.scrub_file(rel, &raw);
+        let lang = lang_for_path(rel);
+        body.push_str(&format!(
+            "### `{}`\n```{lang}\n{}\n```\n\n",
+            rel.display(),
+            content.trim_end()
+        ));
+        included += 1;
+    }
+
+    if included == 0 {
+        return None;
+    }
+
+    let mut header = format!("{included} file(s) included via --files-from");
+    if skipped > 0 {
+        header.push_str(&format!(
+            " ({skipped} listed path(s) skipped: missing, not a regular file, or unreadable)"
+        ));
+    }
+    header.push_str(".\n\n");
+    Some(format!("{header}{body}"))
+}
+
+pub(super) fn try_collect_scoped_findings(
+    root: &Path,
+    findings: &[Finding],
+    scrubber: &Scrubber,
+) -> Option<String> {
+    let mut body = String::new();
+    let mut included = 0_usize;
+    let mut skipped = 0_usize;
+    let mut emitted: HashSet<PathBuf> = HashSet::new();
+
+    for (i, f) in findings.iter().enumerate() {
+        if !emitted.insert(f.primary_path.clone()) {
+            continue;
+        }
+        let abs = if f.primary_path.is_absolute() {
+            f.primary_path.clone()
+        } else {
+            root.join(&f.primary_path)
+        };
+        if !abs.is_file() {
+            skipped += 1;
+            continue;
+        }
+        let raw = match std::fs::read_to_string(&abs) {
+            Ok(s) => s,
+            Err(_) => {
+                skipped += 1;
+                continue;
+            }
+        };
+        let (content, _report) = scrubber.scrub_file(&f.primary_path, &raw);
+        let lang = f.language_hint();
+
+        let co_findings: Vec<&Finding> = findings
+            .iter()
+            .skip(i)
+            .filter(|g| g.primary_path == f.primary_path)
+            .collect();
+        let header = format_file_header(&f.primary_path, &co_findings);
+
+        body.push_str(&format!(
+            "{header}\n```{lang}\n{}\n```\n\n",
+            content.trim_end()
+        ));
+        included += 1;
+    }
+
+    if included == 0 {
+        return None;
+    }
+
+    let mut preamble =
+        format!("{included} file(s) included via --impact-scope (sorted by confidence desc)");
+    if skipped > 0 {
+        preamble.push_str(&format!(
+            "; {skipped} listed path(s) skipped (missing or unreadable)"
+        ));
+    }
+    preamble.push_str(".\n\n");
+    Some(format!("{preamble}{body}"))
+}
+
+pub(super) fn try_collect_per_finding(
+    root: &Path,
+    f: &Finding,
+    idx: usize,
+    scrubber: &Scrubber,
+) -> Option<(String, String)> {
+    let abs = if f.primary_path.is_absolute() {
+        f.primary_path.clone()
+    } else {
+        root.join(&f.primary_path)
+    };
+    if !abs.is_file() {
+        return None;
+    }
+    let raw = std::fs::read_to_string(&abs).ok()?;
+    let (content, _report) = scrubber.scrub_file(&f.primary_path, &raw);
+    let lang = f.language_hint();
+
+    let label = f
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("finding-{}", idx + 1));
+    let descriptor = f.descriptor();
+    let name = if descriptor.is_empty() {
+        format!("📂 Impact: {label}")
+    } else {
+        format!("📂 Impact: {label} ({descriptor})")
+    };
+
+    let mut body = String::new();
+    if let Some(ev) = &f.evidence {
+        body.push_str(&format!("**Evidence:** {ev}\n\n"));
+    }
+    if let Some(act) = &f.suggested_action {
+        body.push_str(&format!("**Suggested action:** `{act}`\n\n"));
+    }
+    body.push_str(&format!(
+        "### `{}`\n```{lang}\n{}\n```\n",
+        f.primary_path.display(),
+        content.trim_end()
+    ));
+
+    Some((name, body))
+}

--- a/crates/cargo-context-core/src/pack/impact.rs
+++ b/crates/cargo-context-core/src/pack/impact.rs
@@ -157,10 +157,9 @@ pub(super) fn try_collect_per_finding(
     let (content, _report) = scrubber.scrub_file(&f.primary_path, &raw);
     let lang = f.language_hint();
 
-    let label = f
-        .id
-        .clone()
-        .unwrap_or_else(|| format!("finding-{}", idx + 1));
+    let label =
+        f.id.clone()
+            .unwrap_or_else(|| format!("finding-{}", idx + 1));
     let descriptor = f.descriptor();
     let name = if descriptor.is_empty() {
         format!("📂 Impact: {label}")

--- a/crates/cargo-context-core/src/pack/mod.rs
+++ b/crates/cargo-context-core/src/pack/mod.rs
@@ -14,8 +14,10 @@ pub mod impact;
 pub mod render;
 
 pub(crate) use render::lang_for_path;
-use render::{mk_section, project_name, render_diagnostics, render_diff_ordered,
-    render_entry, render_map, render_tests};
+use render::{
+    mk_section, project_name, render_diagnostics, render_diff_ordered, render_entry, render_map,
+    render_tests,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -308,8 +310,7 @@ impl PackBuilder {
                 ));
             }
         } else if !self.files_from.is_empty()
-            && let Some(content) =
-                impact::try_collect_scoped(&root, &self.files_from, &scrubber)
+            && let Some(content) = impact::try_collect_scoped(&root, &self.files_from, &scrubber)
         {
             candidates.push((
                 P_DIFF,
@@ -483,9 +484,9 @@ fn try_collect_entry(root: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::impact::*;
     use super::render::lang_for_path;
+    use super::*;
 
     #[test]
     fn builder_includes_prompt_section() {

--- a/crates/cargo-context-core/src/pack/mod.rs
+++ b/crates/cargo-context-core/src/pack/mod.rs
@@ -10,6 +10,13 @@ use crate::impact::Finding;
 use crate::scrub::Scrubber;
 use crate::tokenize::Tokenizer;
 
+pub mod impact;
+pub mod render;
+
+pub(crate) use render::lang_for_path;
+use render::{mk_section, project_name, render_diagnostics, render_diff_ordered,
+    render_entry, render_map, render_tests};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Preset {
@@ -190,67 +197,27 @@ impl PackBuilder {
         self
     }
 
-    /// Repo-relative paths whose full contents should be embedded in a
-    /// dedicated "📂 Scoped Files" section. Designed for the
-    /// `cargo impact --context | cargo context --files-from -` workflow:
-    /// the upstream tool tells us which files matter, and we include them
-    /// verbatim (subject to scrubbing and budget).
-    ///
-    /// These paths also join the diff-changed set when the related-tests
-    /// collector runs, so a test that references a scoped file by stem
-    /// gets surfaced even when the scoped file isn't in `git diff`.
     pub fn files_from(mut self, paths: Vec<std::path::PathBuf>) -> Self {
         self.files_from = paths;
         self
     }
 
-    /// Findings pulled from a `cargo-impact --format=json` envelope.
-    ///
-    /// Differs from [`Self::files_from`] in that each finding carries
-    /// metadata (id, kind, confidence, severity, tier, evidence,
-    /// suggested action) that can drive richer rendering:
-    ///
-    /// - In the default aggregated mode, the list is rendered as a single
-    ///   "📂 Scoped Files" section with files ordered by the caller-supplied
-    ///   order (typically confidence-descending) and per-file headers that
-    ///   surface confidence/severity/tier.
-    /// - When [`Self::impact_per_finding`] is set, each finding becomes its
-    ///   own "📂 Impact: …" section — useful when an agent wants to iterate
-    ///   through findings one at a time.
-    ///
-    /// Finding paths join the diff-changed set for related-tests linkage,
-    /// mirroring `files_from`.
     pub fn impact_findings(mut self, findings: Vec<Finding>) -> Self {
         self.impact_findings = findings;
         self
     }
 
-    /// Emit one pack section per finding instead of one aggregated
-    /// section. No-op when `impact_findings` is empty.
     pub fn impact_per_finding(mut self, on: bool) -> Self {
         self.impact_per_finding = on;
         self
     }
 
-    /// Assemble the pack.
-    ///
-    /// Flow:
-    /// 1. Collect candidate sections per preset (collectors that fail for
-    ///    expected reasons return `None` — a missing git repo or Cargo.toml
-    ///    never aborts the build).
-    /// 2. Run the scrubber over each section's content. Scrubbing may shrink
-    ///    or grow content, so we re-count tokens *after* it.
-    /// 3. Reconcile with the token budget using the configured strategy.
-    ///    Dropped section names are surfaced on `Pack.dropped`.
     pub fn build(self) -> Result<Pack> {
         let root = self
             .project_root
             .clone()
             .unwrap_or_else(|| std::path::PathBuf::from("."));
 
-        // Build the scrubber once, up front. The diff renderer consults it
-        // for path-level `redact_whole` rules; the content scrubber pass
-        // (below) reuses the same instance.
         let scrubber = if self.scrub {
             Scrubber::with_workspace(&root)?
         } else {
@@ -268,8 +235,6 @@ impl PackBuilder {
 
         let wants = SectionWants::for_preset(self.preset);
 
-        // Collect diagnostics as structured data so the diff renderer can
-        // prioritize files with primary error spans.
         let diagnostics = if wants.errors {
             collect::last_error(&root).ok()
         } else {
@@ -290,7 +255,6 @@ impl PackBuilder {
             ));
         }
 
-        // Collect the diff once; share its paths with the tests collector.
         let diff = if wants.diff || wants.tests {
             collect::git_diff(&root, None).ok()
         } else {
@@ -326,22 +290,17 @@ impl PackBuilder {
                 mk_section("🧭 Entry Points", &content, &self.tokenizer),
             ));
         }
-        // Scoped files from `--files-from` or `--impact-scope`. Slotted at
-        // the diff priority: explicit "here is what matters" signals
-        // deserve to survive budget pressure on par with the actual diff.
-        //
-        // impact_findings takes precedence when both are provided —
-        // findings carry richer metadata (confidence, kind) that drives
-        // header/ordering logic.
         if !self.impact_findings.is_empty() {
             if self.impact_per_finding {
                 for (idx, f) in self.impact_findings.iter().enumerate() {
-                    if let Some((name, body)) = try_collect_per_finding(&root, f, idx, &scrubber) {
+                    if let Some((name, body)) =
+                        impact::try_collect_per_finding(&root, f, idx, &scrubber)
+                    {
                         candidates.push((P_DIFF, mk_section(&name, &body, &self.tokenizer)));
                     }
                 }
             } else if let Some(content) =
-                try_collect_scoped_findings(&root, &self.impact_findings, &scrubber)
+                impact::try_collect_scoped_findings(&root, &self.impact_findings, &scrubber)
             {
                 candidates.push((
                     P_DIFF,
@@ -349,7 +308,8 @@ impl PackBuilder {
                 ));
             }
         } else if !self.files_from.is_empty()
-            && let Some(content) = try_collect_scoped(&root, &self.files_from, &scrubber)
+            && let Some(content) =
+                impact::try_collect_scoped(&root, &self.files_from, &scrubber)
         {
             candidates.push((
                 P_DIFF,
@@ -358,8 +318,6 @@ impl PackBuilder {
         }
 
         if wants.tests {
-            // Union of diff-changed, files-from, and impact-finding paths
-            // for related-tests linkage.
             let mut changed: Vec<std::path::PathBuf> = diff
                 .as_ref()
                 .map(|d| d.files.iter().map(|f| f.path.clone()).collect())
@@ -392,7 +350,6 @@ impl PackBuilder {
                 s.token_estimate = self.tokenizer.count(&s.content);
                 scrub_report.redactions.extend(report.redactions);
             }
-            // Honor `report.log_file` if set in scrub.yaml.
             scrubber.log_redactions(&scrub_report)?;
         }
 
@@ -461,9 +418,6 @@ fn try_collect_expansion(root: &Path, mode: ExpandMode, diff: Option<&Diff>) -> 
     }
     let meta = collect::cargo_metadata(root).ok()?;
 
-    // Auto mode: only expand when the diff touches a file with proc-macro
-    // attributes. For the initial pass, treat any diff with .rs files as
-    // meeting the threshold; a smarter heuristic can come later.
     if matches!(mode, ExpandMode::Auto) {
         let has_rust = diff
             .map(|d| {
@@ -509,219 +463,6 @@ fn try_collect_expansion(root: &Path, mode: ExpandMode, diff: Option<&Diff>) -> 
     if expanded_any { Some(out) } else { None }
 }
 
-/// Read each repo-relative path under `root`, scrub it, and emit a fenced
-/// block with a sensible language hint. Missing paths and directories are
-/// silently skipped so that an upstream tool emitting a stale path list
-/// doesn't break pack generation.
-fn try_collect_scoped(
-    root: &Path,
-    paths: &[std::path::PathBuf],
-    scrubber: &Scrubber,
-) -> Option<String> {
-    let mut body = String::new();
-    let mut included = 0_usize;
-    let mut skipped = 0_usize;
-
-    for rel in paths {
-        let abs = if rel.is_absolute() {
-            rel.clone()
-        } else {
-            root.join(rel)
-        };
-        if !abs.is_file() {
-            skipped += 1;
-            continue;
-        }
-        let raw = match std::fs::read_to_string(&abs) {
-            Ok(s) => s,
-            Err(_) => {
-                skipped += 1;
-                continue;
-            }
-        };
-        let (content, _report) = scrubber.scrub_file(rel, &raw);
-        let lang = lang_for_path(rel);
-        body.push_str(&format!(
-            "### `{}`\n```{lang}\n{}\n```\n\n",
-            rel.display(),
-            content.trim_end()
-        ));
-        included += 1;
-    }
-
-    if included == 0 {
-        return None;
-    }
-
-    let mut header = format!("{included} file(s) included via --files-from");
-    if skipped > 0 {
-        header.push_str(&format!(
-            " ({skipped} listed path(s) skipped: missing, not a regular file, or unreadable)"
-        ));
-    }
-    header.push_str(".\n\n");
-    Some(format!("{header}{body}"))
-}
-
-/// Aggregated impact-scope rendering: one Scoped Files section with
-/// per-file headers showing the finding's confidence/severity/tier and
-/// kind-aware language hints. Findings are rendered in the order passed
-/// in (the CLI sorts by confidence desc before building), deduped by
-/// path so a file referenced by many findings only renders once — with
-/// the other findings summarized in its header.
-fn try_collect_scoped_findings(
-    root: &Path,
-    findings: &[Finding],
-    scrubber: &Scrubber,
-) -> Option<String> {
-    let mut body = String::new();
-    let mut included = 0_usize;
-    let mut skipped = 0_usize;
-    let mut emitted: std::collections::HashSet<std::path::PathBuf> =
-        std::collections::HashSet::new();
-
-    for (i, f) in findings.iter().enumerate() {
-        if !emitted.insert(f.primary_path.clone()) {
-            continue;
-        }
-        let abs = if f.primary_path.is_absolute() {
-            f.primary_path.clone()
-        } else {
-            root.join(&f.primary_path)
-        };
-        if !abs.is_file() {
-            skipped += 1;
-            continue;
-        }
-        let raw = match std::fs::read_to_string(&abs) {
-            Ok(s) => s,
-            Err(_) => {
-                skipped += 1;
-                continue;
-            }
-        };
-        let (content, _report) = scrubber.scrub_file(&f.primary_path, &raw);
-        let lang = f.language_hint();
-
-        // Gather every finding that names this path — the first drove
-        // inclusion, the rest get summarized on the same header.
-        let co_findings: Vec<&Finding> = findings
-            .iter()
-            .skip(i)
-            .filter(|g| g.primary_path == f.primary_path)
-            .collect();
-        let header = format_file_header(&f.primary_path, &co_findings);
-
-        body.push_str(&format!(
-            "{header}\n```{lang}\n{}\n```\n\n",
-            content.trim_end()
-        ));
-        included += 1;
-    }
-
-    if included == 0 {
-        return None;
-    }
-
-    let mut preamble =
-        format!("{included} file(s) included via --impact-scope (sorted by confidence desc)");
-    if skipped > 0 {
-        preamble.push_str(&format!(
-            "; {skipped} listed path(s) skipped (missing or unreadable)"
-        ));
-    }
-    preamble.push_str(".\n\n");
-    Some(format!("{preamble}{body}"))
-}
-
-/// Per-finding rendering: each finding becomes a standalone section. The
-/// caller slots these at `P_DIFF` just like the aggregated form, so
-/// low-confidence findings still benefit from budget pressure — the
-/// allocate step drops the tail when the pack overflows.
-fn try_collect_per_finding(
-    root: &Path,
-    f: &Finding,
-    idx: usize,
-    scrubber: &Scrubber,
-) -> Option<(String, String)> {
-    let abs = if f.primary_path.is_absolute() {
-        f.primary_path.clone()
-    } else {
-        root.join(&f.primary_path)
-    };
-    if !abs.is_file() {
-        return None;
-    }
-    let raw = std::fs::read_to_string(&abs).ok()?;
-    let (content, _report) = scrubber.scrub_file(&f.primary_path, &raw);
-    let lang = f.language_hint();
-
-    let label =
-        f.id.clone()
-            .unwrap_or_else(|| format!("finding-{}", idx + 1));
-    let descriptor = f.descriptor();
-    let name = if descriptor.is_empty() {
-        format!("📂 Impact: {label}")
-    } else {
-        format!("📂 Impact: {label} ({descriptor})")
-    };
-
-    let mut body = String::new();
-    if let Some(ev) = &f.evidence {
-        body.push_str(&format!("**Evidence:** {ev}\n\n"));
-    }
-    if let Some(act) = &f.suggested_action {
-        body.push_str(&format!("**Suggested action:** `{act}`\n\n"));
-    }
-    body.push_str(&format!(
-        "### `{}`\n```{lang}\n{}\n```\n",
-        f.primary_path.display(),
-        content.trim_end()
-    ));
-
-    Some((name, body))
-}
-
-/// Build a per-file header for the aggregated Scoped Files section. When
-/// several findings name the same path, list each finding's
-/// id+descriptor so the reader can still correlate file content with
-/// analyzer hits.
-fn format_file_header(path: &Path, findings: &[&Finding]) -> String {
-    let mut header = format!("### `{}`", path.display());
-    let labels: Vec<String> = findings
-        .iter()
-        .map(|f| {
-            let id = f.id.as_deref().unwrap_or("finding");
-            let d = f.descriptor();
-            if d.is_empty() {
-                id.to_string()
-            } else {
-                format!("{id}: {d}")
-            }
-        })
-        .collect();
-    if !labels.is_empty() {
-        header.push_str(" — ");
-        header.push_str(&labels.join("; "));
-    }
-    header
-}
-
-pub(crate) fn lang_for_path(path: &Path) -> &'static str {
-    match path.extension().and_then(|e| e.to_str()) {
-        Some("rs") => "rust",
-        Some("toml") => "toml",
-        Some("yaml" | "yml") => "yaml",
-        Some("json") => "json",
-        Some("md") => "markdown",
-        Some("sh" | "bash") => "bash",
-        Some("py") => "python",
-        Some("ts") => "typescript",
-        Some("js") => "javascript",
-        _ => "",
-    }
-}
-
 fn try_collect_tests(root: &Path, changed: &[std::path::PathBuf]) -> Option<String> {
     let rt = collect::related_tests(root, changed).ok()?;
     if rt.is_empty() {
@@ -740,234 +481,11 @@ fn try_collect_entry(root: &Path) -> Option<String> {
     }
 }
 
-fn render_tests(rt: &RelatedTests) -> String {
-    let mut out = String::new();
-    out.push_str(&format!("{} related test file(s).\n\n", rt.files.len()));
-    for f in &rt.files {
-        let kind = match f.kind {
-            collect::TestKind::Integration => "integration",
-            collect::TestKind::UnitInline => "unit (inline)",
-        };
-        let reason = if f.matched_stems.is_empty() {
-            String::new()
-        } else {
-            format!(" — matched: `{}`", f.matched_stems.join("`, `"))
-        };
-        out.push_str(&format!(
-            "### `{}` — {} / {} ({} tests){}\n",
-            f.path.display(),
-            f.crate_name,
-            kind,
-            f.functions.len(),
-            reason,
-        ));
-        for fun in &f.functions {
-            out.push_str(&format!("- `{}`\n", fun.signature.trim()));
-        }
-        out.push('\n');
-    }
-    out
-}
-
-fn render_entry(ep: &EntryPoints) -> String {
-    let mut out = String::new();
-    out.push_str(&format!("{} entry file(s).\n\n", ep.files.len()));
-    for f in &ep.files {
-        let kind = match f.kind {
-            collect::EntryKind::Main => "main",
-            collect::EntryKind::Lib => "lib",
-        };
-        let tag = if f.parse_failed { " (unparsed)" } else { "" };
-        out.push_str(&format!(
-            "### `{}` — {} / {} ({} lines){}\n",
-            f.path.display(),
-            f.crate_name,
-            kind,
-            f.raw_line_count,
-            tag,
-        ));
-        out.push_str("```rust\n");
-        out.push_str(&f.rendered);
-        if !f.rendered.ends_with('\n') {
-            out.push('\n');
-        }
-        out.push_str("```\n\n");
-    }
-    out
-}
-
-fn render_map(m: WorkspaceMap) -> String {
-    let mut out = String::new();
-    if let Some(root) = &m.root_package {
-        out.push_str(&format!("- Root package: `{root}`\n"));
-    }
-    let members = m.member_names();
-    if !members.is_empty() {
-        out.push_str(&format!("- Workspace members ({}): ", members.len()));
-        out.push_str(&members.join(", "));
-        out.push('\n');
-    }
-    let deps = m.external_dep_names();
-    if !deps.is_empty() {
-        let preview: Vec<&str> = deps.iter().take(12).copied().collect();
-        out.push_str(&format!(
-            "- Key dependencies: {}{}\n",
-            preview.join(", "),
-            if deps.len() > preview.len() {
-                format!(" (+{} more)", deps.len() - preview.len())
-            } else {
-                String::new()
-            }
-        ));
-    }
-    out
-}
-
-/// Render a diff with files containing primary error spans ordered first.
-/// Under budget pressure, earlier sections survive truncation, so this
-/// keeps the most signal-dense files when the budget forces a cut.
-///
-/// The `scrubber` argument consults `redact_whole` globs: files that match
-/// render with their hunks elided and a `[REDACTED FILE: ...]` marker in
-/// their place — keeping the fact-of-change visible without leaking the
-/// contents (e.g. for `.env` or `.pem` files that showed up in the diff).
-fn render_diff_ordered(
-    d: &Diff,
-    error_files: &[std::path::PathBuf],
-    scrubber: &Scrubber,
-) -> String {
-    let error_set: std::collections::HashSet<&Path> =
-        error_files.iter().map(|p| p.as_path()).collect();
-
-    let mut files: Vec<&collect::FileDiff> = d.files.iter().collect();
-    files.sort_by_key(|f| {
-        // Files with errors first (0), then by alphabetical path.
-        let has_error = error_set.contains(f.path.as_path())
-            || error_files.iter().any(|e| path_matches_suffix(&f.path, e));
-        (!has_error, f.path.to_string_lossy().into_owned())
-    });
-
-    let errored_count = files
-        .iter()
-        .filter(|f| {
-            error_set.contains(f.path.as_path())
-                || error_files.iter().any(|e| path_matches_suffix(&f.path, e))
-        })
-        .count();
-    let path_redacted_count = files
-        .iter()
-        .filter(|f| scrubber.is_path_redacted(&f.path))
-        .count();
-
-    let mut out = String::new();
-    let mut header = format!("{} file(s) changed", d.files.len());
-    if errored_count > 0 {
-        header.push_str(&format!(
-            "; {errored_count} touched by compiler errors (shown first)"
-        ));
-    }
-    if path_redacted_count > 0 {
-        header.push_str(&format!("; {path_redacted_count} redacted by path rules"));
-    }
-    out.push_str(&format!("{header}.\n\n"));
-
-    for f in files {
-        let status = format!("{:?}", f.status).to_lowercase();
-        let error_marker = if error_set.contains(f.path.as_path())
-            || error_files.iter().any(|e| path_matches_suffix(&f.path, e))
-        {
-            " ⚠"
-        } else {
-            ""
-        };
-        let redacted = scrubber.is_path_redacted(&f.path);
-        let redact_marker = if redacted { " 🔒" } else { "" };
-
-        out.push_str(&format!(
-            "### `{}` — {status}{error_marker}{redact_marker}\n",
-            f.path.display()
-        ));
-        if let Some(old) = &f.old_path {
-            out.push_str(&format!("- Renamed from `{}`\n", old.display()));
-        }
-        if redacted {
-            out.push_str(&format!(
-                "[REDACTED FILE: {} — {} hunk(s) elided by scrub.yaml path rules]\n",
-                f.path.display(),
-                f.hunks.len()
-            ));
-        } else {
-            for h in &f.hunks {
-                out.push_str(&format!(
-                    "```diff\n@@ -{},{} +{},{} @@\n{}```\n",
-                    h.old_start, h.old_lines, h.new_start, h.new_lines, h.body
-                ));
-            }
-        }
-        out.push('\n');
-    }
-    out
-}
-
-/// Compiler diagnostics and git diff often use different path anchors
-/// (relative to the crate vs. relative to the workspace). Matching by
-/// suffix is a pragmatic bridge.
-fn path_matches_suffix(haystack: &Path, needle: &Path) -> bool {
-    let h = haystack.to_string_lossy();
-    let n = needle.to_string_lossy();
-    h.ends_with(n.as_ref()) || n.ends_with(h.as_ref())
-}
-
-fn render_diagnostics(d: &Diagnostics) -> String {
-    let mut out = String::new();
-    let err_count = d
-        .diagnostics
-        .iter()
-        .filter(|x| x.level == crate::collect::DiagLevel::Error)
-        .count();
-    out.push_str(&format!(
-        "Build {}; {} diagnostic(s), {} error(s).\n\n",
-        if d.success { "succeeded" } else { "failed" },
-        d.diagnostics.len(),
-        err_count,
-    ));
-    for diag in &d.diagnostics {
-        let code = diag.code.as_deref().unwrap_or("");
-        out.push_str(&format!(
-            "- **{:?}** {}: {}\n",
-            diag.level, code, diag.message
-        ));
-        if let Some(file) = diag.primary_file()
-            && let Some(span) = diag.spans.iter().find(|s| s.is_primary)
-        {
-            out.push_str(&format!(
-                "  at `{}:{}:{}`\n",
-                file.display(),
-                span.line_start,
-                span.col_start
-            ));
-        }
-    }
-    out
-}
-
-fn mk_section(name: &str, content: &str, tokenizer: &Tokenizer) -> Section {
-    Section {
-        name: name.into(),
-        content: content.into(),
-        token_estimate: tokenizer.count(content),
-    }
-}
-
-fn project_name(root: Option<&std::path::Path>) -> String {
-    root.and_then(|p| p.file_name())
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "unknown".to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::impact::*;
+    use super::render::lang_for_path;
 
     #[test]
     fn builder_includes_prompt_section() {
@@ -975,7 +493,7 @@ mod tests {
             .preset(Preset::Fix)
             .max_tokens(4000)
             .stdin_prompt("why does this fail?")
-            .project_root(std::env::temp_dir()) // force empty collection
+            .project_root(std::env::temp_dir())
             .build()
             .expect("build pack");
         assert_eq!(pack.schema, "cargo-context/v1");
@@ -984,8 +502,6 @@ mod tests {
 
     #[test]
     fn builder_empty_workspace_is_valid() {
-        // A clean workspace with no diff and no errors produces an empty pack —
-        // that is a valid result, not an error.
         let pack = PackBuilder::new()
             .preset(Preset::Fix)
             .project_root(std::env::temp_dir())
@@ -1036,7 +552,6 @@ mod tests {
         let errors = vec![std::path::PathBuf::from("src/broken.rs")];
         let scrubber = Scrubber::empty();
         let rendered = render_diff_ordered(&d, &errors, &scrubber);
-        // The broken file should render before the unrelated ones.
         let broken_pos = rendered.find("broken.rs").unwrap();
         let unrelated_pos = rendered.find("unrelated.rs").unwrap();
         let clean_pos = rendered.find("also_clean.rs").unwrap();
@@ -1075,13 +590,12 @@ mod tests {
         let scrubber = Scrubber::empty();
         let rendered = render_diff_ordered(&d, &[], &scrubber);
         assert!(rendered.find("a.rs").unwrap() < rendered.find("b.rs").unwrap());
-        // No warning marker when no errors are present.
         assert!(!rendered.contains('⚠'));
     }
 
     #[test]
     fn render_diff_path_rules_redact_matching_files() {
-        use crate::collect::{Diff, FileDiff, FileStatus};
+        use crate::collect::{Diff, DiffHunk, FileDiff, FileStatus};
         use crate::scrub::ScrubConfig;
 
         let d = Diff {
@@ -1091,7 +605,7 @@ mod tests {
                     path: std::path::PathBuf::from("src/lib.rs"),
                     old_path: None,
                     status: FileStatus::Modified,
-                    hunks: vec![crate::collect::DiffHunk {
+                    hunks: vec![DiffHunk {
                         old_start: 1,
                         old_lines: 1,
                         new_start: 1,
@@ -1104,7 +618,7 @@ mod tests {
                     path: std::path::PathBuf::from(".env"),
                     old_path: None,
                     status: FileStatus::Modified,
-                    hunks: vec![crate::collect::DiffHunk {
+                    hunks: vec![DiffHunk {
                         old_start: 1,
                         old_lines: 1,
                         new_start: 1,
@@ -1125,7 +639,6 @@ mod tests {
         let scrubber = Scrubber::from_config(&config).unwrap();
         let rendered = render_diff_ordered(&d, &[], &scrubber);
 
-        // .env's hunk body is elided; lib.rs's isn't.
         assert!(
             !rendered.contains("SECRET=new"),
             "redacted hunk content leaked into diff render: {rendered}"
@@ -1209,7 +722,6 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("hot.rs"), "fn hot() {}\n").unwrap();
         std::fs::write(tmp.path().join("warm.rs"), "fn warm() {}\n").unwrap();
-        // cold.rs intentionally missing to exercise the skipped counter.
 
         let scrubber = Scrubber::empty();
         let findings = vec![
@@ -1246,14 +758,11 @@ mod tests {
         ];
         let out = try_collect_scoped_findings(tmp.path(), &findings, &scrubber)
             .expect("at least one finding resolves");
-        // Higher-confidence file comes first in the caller-ordered list.
         assert!(
             out.find("hot.rs").unwrap() < out.find("warm.rs").unwrap(),
             "hot.rs should render before warm.rs:\n{out}"
         );
-        // Per-file header surfaces id + descriptor.
         assert!(out.contains("f-hot: trait_impl, high/likely, conf=0.95"));
-        // Missing finding is counted, not fatal.
         assert!(
             out.contains("1 listed path(s) skipped"),
             "expected skipped counter in header: {out}"
@@ -1291,12 +800,9 @@ mod tests {
         ];
         let out = try_collect_scoped_findings(tmp.path(), &findings, &scrubber).unwrap();
 
-        // Single rendered file block.
         assert_eq!(out.matches("### `shared.rs`").count(), 1);
-        // Both finding ids land in the shared header.
         assert!(out.contains("f1"));
         assert!(out.contains("f2"));
-        // Header reports 1 file even though 2 findings fed it.
         assert!(out.contains("1 file(s) included via --impact-scope"));
     }
 
@@ -1338,7 +844,6 @@ mod tests {
         assert!(body_a.contains("fn a() {}"));
 
         let (name_b, body_b) = try_collect_per_finding(tmp.path(), &fb, 1, &scrubber).unwrap();
-        // No id would fall back to finding-N, but fb has an id.
         assert_eq!(name_b, "📂 Impact: f-bbb");
         assert!(!body_b.contains("**Evidence:**"));
         assert!(body_b.contains("fn b() {}"));

--- a/crates/cargo-context-core/src/pack/mod.rs
+++ b/crates/cargo-context-core/src/pack/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::budget::{self, Budget, P_DIFF, P_ENTRY, P_ERROR, P_EXEMPT, P_MAP, P_TESTS, Priority};
-use crate::collect::{self, Diagnostics, Diff, EntryPoints, RelatedTests, WorkspaceMap};
+use crate::collect::{self, Diff};
 use crate::error::Result;
 use crate::expand::{self, ExpandMode};
 use crate::impact::Finding;

--- a/crates/cargo-context-core/src/pack/render.rs
+++ b/crates/cargo-context-core/src/pack/render.rs
@@ -1,0 +1,235 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::collect::{self, Diagnostics, Diff, EntryPoints, RelatedTests, WorkspaceMap};
+use crate::scrub::Scrubber;
+use crate::tokenize::Tokenizer;
+
+use super::Section;
+
+pub(super) fn mk_section(name: &str, content: &str, tokenizer: &Tokenizer) -> Section {
+    Section {
+        name: name.into(),
+        content: content.into(),
+        token_estimate: tokenizer.count(content),
+    }
+}
+
+pub(super) fn project_name(root: Option<&std::path::Path>) -> String {
+    root.and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+pub(crate) fn lang_for_path(path: &Path) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("rs") => "rust",
+        Some("toml") => "toml",
+        Some("yaml" | "yml") => "yaml",
+        Some("json") => "json",
+        Some("md") => "markdown",
+        Some("sh" | "bash") => "bash",
+        Some("py") => "python",
+        Some("ts") => "typescript",
+        Some("js") => "javascript",
+        _ => "",
+    }
+}
+
+fn path_matches_suffix(haystack: &Path, needle: &Path) -> bool {
+    let h = haystack.to_string_lossy();
+    let n = needle.to_string_lossy();
+    h.ends_with(n.as_ref()) || n.ends_with(h.as_ref())
+}
+
+pub(super) fn render_tests(rt: &RelatedTests) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{} related test file(s).\n\n", rt.files.len()));
+    for f in &rt.files {
+        let kind = match f.kind {
+            collect::TestKind::Integration => "integration",
+            collect::TestKind::UnitInline => "unit (inline)",
+        };
+        let reason = if f.matched_stems.is_empty() {
+            String::new()
+        } else {
+            format!(" — matched: `{}`", f.matched_stems.join("`, `"))
+        };
+        out.push_str(&format!(
+            "### `{}` — {} / {} ({} tests){}\n",
+            f.path.display(),
+            f.crate_name,
+            kind,
+            f.functions.len(),
+            reason,
+        ));
+        for fun in &f.functions {
+            out.push_str(&format!("- `{}`\n", fun.signature.trim()));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+pub(super) fn render_entry(ep: &EntryPoints) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{} entry file(s).\n\n", ep.files.len()));
+    for f in &ep.files {
+        let kind = match f.kind {
+            collect::EntryKind::Main => "main",
+            collect::EntryKind::Lib => "lib",
+        };
+        let tag = if f.parse_failed { " (unparsed)" } else { "" };
+        out.push_str(&format!(
+            "### `{}` — {} / {} ({} lines){}\n",
+            f.path.display(),
+            f.crate_name,
+            kind,
+            f.raw_line_count,
+            tag,
+        ));
+        out.push_str("```rust\n");
+        out.push_str(&f.rendered);
+        if !f.rendered.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("```\n\n");
+    }
+    out
+}
+
+pub(super) fn render_map(m: WorkspaceMap) -> String {
+    let mut out = String::new();
+    if let Some(root) = &m.root_package {
+        out.push_str(&format!("- Root package: `{root}`\n"));
+    }
+    let members = m.member_names();
+    if !members.is_empty() {
+        out.push_str(&format!("- Workspace members ({}): ", members.len()));
+        out.push_str(&members.join(", "));
+        out.push('\n');
+    }
+    let deps = m.external_dep_names();
+    if !deps.is_empty() {
+        let preview: Vec<&str> = deps.iter().take(12).copied().collect();
+        out.push_str(&format!(
+            "- Key dependencies: {}{}\n",
+            preview.join(", "),
+            if deps.len() > preview.len() {
+                format!(" (+{} more)", deps.len() - preview.len())
+            } else {
+                String::new()
+            }
+        ));
+    }
+    out
+}
+
+pub(super) fn render_diff_ordered(
+    d: &Diff,
+    error_files: &[std::path::PathBuf],
+    scrubber: &Scrubber,
+) -> String {
+    let error_set: HashSet<&Path> = error_files.iter().map(|p| p.as_path()).collect();
+
+    let mut files: Vec<&collect::FileDiff> = d.files.iter().collect();
+    files.sort_by_key(|f| {
+        let has_error = error_set.contains(f.path.as_path())
+            || error_files.iter().any(|e| path_matches_suffix(&f.path, e));
+        (!has_error, f.path.to_string_lossy().into_owned())
+    });
+
+    let errored_count = files
+        .iter()
+        .filter(|f| {
+            error_set.contains(f.path.as_path())
+                || error_files.iter().any(|e| path_matches_suffix(&f.path, e))
+        })
+        .count();
+    let path_redacted_count = files
+        .iter()
+        .filter(|f| scrubber.is_path_redacted(&f.path))
+        .count();
+
+    let mut out = String::new();
+    let mut header = format!("{} file(s) changed", d.files.len());
+    if errored_count > 0 {
+        header.push_str(&format!(
+            "; {errored_count} touched by compiler errors (shown first)"
+        ));
+    }
+    if path_redacted_count > 0 {
+        header.push_str(&format!("; {path_redacted_count} redacted by path rules"));
+    }
+    out.push_str(&format!("{header}.\n\n"));
+
+    for f in files {
+        let status = format!("{:?}", f.status).to_lowercase();
+        let error_marker = if error_set.contains(f.path.as_path())
+            || error_files.iter().any(|e| path_matches_suffix(&f.path, e))
+        {
+            " ⚠"
+        } else {
+            ""
+        };
+        let redacted = scrubber.is_path_redacted(&f.path);
+        let redact_marker = if redacted { " 🔒" } else { "" };
+
+        out.push_str(&format!(
+            "### `{}` — {status}{error_marker}{redact_marker}\n",
+            f.path.display()
+        ));
+        if let Some(old) = &f.old_path {
+            out.push_str(&format!("- Renamed from `{}`\n", old.display()));
+        }
+        if redacted {
+            out.push_str(&format!(
+                "[REDACTED FILE: {} — {} hunk(s) elided by scrub.yaml path rules]\n",
+                f.path.display(),
+                f.hunks.len()
+            ));
+        } else {
+            for h in &f.hunks {
+                out.push_str(&format!(
+                    "```diff\n@@ -{},{} +{},{} @@\n{}```\n",
+                    h.old_start, h.old_lines, h.new_start, h.new_lines, h.body
+                ));
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+pub(super) fn render_diagnostics(d: &Diagnostics) -> String {
+    let mut out = String::new();
+    let err_count = d
+        .diagnostics
+        .iter()
+        .filter(|x| x.level == crate::collect::DiagLevel::Error)
+        .count();
+    out.push_str(&format!(
+        "Build {}; {} diagnostic(s), {} error(s).\n\n",
+        if d.success { "succeeded" } else { "failed" },
+        d.diagnostics.len(),
+        err_count,
+    ));
+    for diag in &d.diagnostics {
+        let code = diag.code.as_deref().unwrap_or("");
+        out.push_str(&format!(
+            "- **{:?}** {}: {}\n",
+            diag.level, code, diag.message
+        ));
+        if let Some(file) = diag.primary_file()
+            && let Some(span) = diag.spans.iter().find(|s| s.is_primary)
+        {
+            out.push_str(&format!(
+                "  at `{}:{}:{}`\n",
+                file.display(),
+                span.line_start,
+                span.col_start
+            ));
+        }
+    }
+    out
+}


### PR DESCRIPTION
## Summary

Refactors `pack.rs` (1437 lines) into three submodules:

- `pack/mod.rs` (~550 lines) — core types (Preset, Format, Section, Pack, PackBuilder), SectionWants, build() orchestration, collector helper functions, and tests
- `pack/render.rs` (~235 lines) — standalone render functions + utilities (render_diff_ordered, render_diagnostics, render_tests, render_entry, render_map, lang_for_path, mk_section, project_name)
- `pack/impact.rs` (~185 lines) — impact-specific rendering (try_collect_scoped, try_collect_scoped_findings, try_collect_per_finding, format_file_header)

All 113 tests pass. `lang_for_path` is re-exported at `crate::pack::lang_for_path` for backward compatibility with the `impact` module.

Closes #7