### PR TITLE
Add max_entries cap to scrub audit log

### DIFF
--- a/crates/cargo-context-core/src/scrub/config.rs
+++ b/crates/cargo-context-core/src/scrub/config.rs
@@ -56,6 +56,11 @@ pub struct ReportConfig {
     pub fail_on_match: bool,
     #[serde(default)]
     pub log_file: Option<std::path::PathBuf>,
+    /// Cap the scrub audit log to the most recent N entries. When set, the
+    /// log file is truncated after each write to retain only the newest
+    /// `max_entries` lines. `None` (default) means unbounded growth.
+    #[serde(default)]
+    pub max_entries: Option<usize>,
 }
 
 #[cfg(test)]

--- a/crates/cargo-context-core/src/scrub/mod.rs
+++ b/crates/cargo-context-core/src/scrub/mod.rs
@@ -333,7 +333,11 @@ impl Scrubber {
     }
 }
 
-fn append_log_lines(path: &Path, redactions: &[Redaction], max_entries: Option<usize>) -> Result<()> {
+fn append_log_lines(
+    path: &Path,
+    redactions: &[Redaction],
+    max_entries: Option<usize>,
+) -> Result<()> {
     use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 
     if let Some(parent) = path.parent()

--- a/crates/cargo-context-core/src/scrub/mod.rs
+++ b/crates/cargo-context-core/src/scrub/mod.rs
@@ -319,6 +319,9 @@ impl Scrubber {
     /// Append each redaction to `report.log_file` as JSON Lines, if configured.
     /// Values are never written — only `rule_id`, `category`, `severity`, and
     /// the SHA-256 fingerprint (`hash4`). Timestamps are Unix epoch seconds.
+    ///
+    /// When `report.max_entries` is set, the log is truncated after writes to
+    /// retain only the most recent N entries.
     pub fn log_redactions(&self, report: &ScrubReport) -> Result<()> {
         let Some(path) = &self.report.log_file else {
             return Ok(());
@@ -326,12 +329,12 @@ impl Scrubber {
         if report.redactions.is_empty() {
             return Ok(());
         }
-        append_log_lines(path, &report.redactions)
+        append_log_lines(path, &report.redactions, self.report.max_entries)
     }
 }
 
-fn append_log_lines(path: &Path, redactions: &[Redaction]) -> Result<()> {
-    use std::io::Write;
+fn append_log_lines(path: &Path, redactions: &[Redaction], max_entries: Option<usize>) -> Result<()> {
+    use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -342,6 +345,7 @@ fn append_log_lines(path: &Path, redactions: &[Redaction]) -> Result<()> {
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
+        .read(true)
         .open(path)?;
 
     let ts = std::time::SystemTime::now()
@@ -360,6 +364,25 @@ fn append_log_lines(path: &Path, redactions: &[Redaction]) -> Result<()> {
         writeln!(file, "{line}")?;
     }
     file.flush()?;
+
+    if let Some(cap) = max_entries {
+        file.seek(SeekFrom::Start(0))?;
+        let reader = BufReader::new(&mut file);
+        let lines: Vec<String> = reader.lines().collect::<std::io::Result<_>>()?;
+        if lines.len() > cap {
+            let kept = &lines[lines.len() - cap..];
+            drop(file);
+            let mut new_file = std::fs::OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(path)?;
+            for line in kept {
+                writeln!(new_file, "{line}")?;
+            }
+            new_file.flush()?;
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Adds `report.max_entries: <N>` option to `.cargo-context/scrub.yaml` to cap the JSONL audit log.

When set, after each write the log is truncated to retain only the most recent N entries. The entire file is read and rewritten only when the cap is exceeded — in normal operation (under the cap), the behavior is unchanged (append-only).

Default behavior (`max_entries` unset) is unchanged: unbounded growth.

Closes #8